### PR TITLE
fix target filter keys

### DIFF
--- a/src/steps/alerts/index.ts
+++ b/src/steps/alerts/index.ts
@@ -71,7 +71,7 @@ async function fetchAlertPolicies({
         await jobState.addRelationship(
           createMappedRelationship({
             source: alertPolicyEntity,
-            targetFilterKeys: ['teamId', 'name'],
+            targetFilterKeys: [['teamId', 'name']],
             _type:
               MappedRelationships.ALERT_POLICY_NOTIFIES_SLACK_CHANNEL._type,
             target: {


### PR DESCRIPTION
# Description

This PR fixes an error with `targetFilterKeys` for the alert -> Notifies -> slack_channel
